### PR TITLE
Deny absolute bower main file,

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -128,6 +128,10 @@ Package.prototype = {
         }
 
         main.forEach(function(pattern) {
+            if (pattern[0] === '/') {
+                throw new Error('absolute path in bower main is not supported');
+            }
+
             var _files = globby(pattern, {
                 cwd: this.path
             });


### PR DESCRIPTION
When using /build/xx.js in bower.main (yes, it's wrong, but main-bower-files should report the wrongness).    It will introduce a wrong error message like /Users/name/project/bower_components/build/xx.js not found in path.

But actually the path is correct and file is there. 

Totally deny bower main with / path is  an easy fix.

BTW, bower.json main does not support with the  glob, we'd better not using the pattern match here. 
